### PR TITLE
chore: add reopen-issue-if-prs-open workflow

### DIFF
--- a/.github/workflows/reopen-issue-if-prs-open.yml
+++ b/.github/workflows/reopen-issue-if-prs-open.yml
@@ -1,0 +1,11 @@
+name: Reopen Issue If PRs Open
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  reopen-if-needed:
+    uses: RequestNetwork/.github/.github/workflows/reopen-issue-if-prs-open.yml@main
+    secrets:
+      token: ${{ secrets.REOPEN_ISSUES_TOKEN }}


### PR DESCRIPTION
Adds workflow that reopens issues when closed while linked PRs are still open.

Fixes RequestNetwork/public-issues#131